### PR TITLE
Fix do-wrapper API issues

### DIFF
--- a/create.js
+++ b/create.js
@@ -1,5 +1,5 @@
 const randomstring = require('randomstring')
-const DigitalOcean = require('do-wrapper')
+const DigitalOcean = require('do-wrapper').default
 const eSettings = require('electron-settings')
 const request = require('request')
 const _ = require('underscore')

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const create = require('./create')
 const path = require('path')
 const async = require('async')
 const ChildProcess = require('child_process')
-var DigitalOcean = require('do-wrapper'),
+var DigitalOcean = require('do-wrapper').default,
     api = null;
 
 var win, settingsWin;
@@ -330,7 +330,7 @@ electron.ipcMain.on('fetchForImages', function(event) {
             })
         }
 
-        api.imagesGetAll({}, function(err, resp, body) {
+        api.imagesGetAll({type: 'distribution'}, function(err, resp, body) {
             if (err) {
                 // Return Error to Window
                 win.webContents.send('initError');


### PR DESCRIPTION
Found two issues, preventing easy-proxy from running properly:
1) Location of do-wrapper's constructor has changed, must now be imported as `require('do-wrapper').default`.
2) To return all distributions, getImagesAll must be called with `type=distribution` now.

This fixes both the "DigitalOcean is not a constructor" error, and the "CentOS 7 not found" error. (Maybe also fixes the hanging on fetching images, which might be caused by the constructor issue.)